### PR TITLE
Patch Screener Networking

### DIFF
--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -6,7 +6,7 @@
 #   security_groups = [aws_security_group.allow-screener-traffic.id]
 # }
 # resource "aws_lb_listener" "screener" {
-  
+
 # }
 # security group for screener
 resource "aws_security_group" "allow-screener-traffic" {

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -5,13 +5,21 @@ resource "aws_security_group" "allow-screener-traffic" {
   vpc_id      = module.constants.vpc_id
 
   ingress {
-    description = "TCP traffic from VPC"
-    from_port   = 80
-    to_port     = 80
+    description = "VPC traffic"
+    from_port   = 443
+    to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/8"]
+    # use security group as the source
+    cidr_blocks = ["172.31.0.0/16"] # ip range of the VPC
   }
-
+  ingress {
+    description = "Allow traffic from internet"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    # use security group as the source
+    cidr_blocks = ["0.0.0.0/0"] # ip range of the VPC
+  }
   egress {
     description      = "allow all outbound traffic from screener"
     from_port        = 0

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "allow-screener-traffic" {
   name        = "allow_screener_traffic"
   description = "This rule blocks all traffic unless it is HTTPS for the eligibility screener"
   vpc_id      = module.constants.vpc_id
-  
+
   ingress {
     description = "Allow traffic from internet"
     from_port   = 3000

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -3,15 +3,7 @@ resource "aws_security_group" "allow-screener-traffic" {
   name        = "allow_screener_traffic"
   description = "This rule blocks all traffic unless it is HTTPS for the eligibility screener"
   vpc_id      = module.constants.vpc_id
-
-  ingress {
-    description = "VPC traffic"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    # use security group as the source
-    cidr_blocks = ["172.31.0.0/16"] # ip range of the VPC
-  }
+  
   ingress {
     description = "Allow traffic from internet"
     from_port   = 3000

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -1,3 +1,13 @@
+# load balancer to redirect
+# resource "aws_lb" "screener" {
+#   name = "${var.environment_name}-screener-lb"
+#   internal = false
+#   load_balancer_type = "application"
+#   security_groups = [aws_security_group.allow-screener-traffic.id]
+# }
+# resource "aws_lb_listener" "screener" {
+  
+# }
 # security group for screener
 resource "aws_security_group" "allow-screener-traffic" {
   name        = "allow_screener_traffic"
@@ -7,7 +17,7 @@ resource "aws_security_group" "allow-screener-traffic" {
   ingress {
     description = "Allow traffic from internet"
     from_port   = 3000
-    to_port     = 8080
+    to_port     = 3000
     protocol    = "tcp"
     # use security group as the source
     cidr_blocks = ["0.0.0.0/0"] # ip range of the VPC

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -7,7 +7,7 @@ resource "aws_security_group" "allow-screener-traffic" {
   ingress {
     description = "Allow traffic from internet"
     from_port   = 3000
-    to_port     = 3000
+    to_port     = 8080
     protocol    = "tcp"
     # use security group as the source
     cidr_blocks = ["0.0.0.0/0"] # ip range of the VPC


### PR DESCRIPTION
## Ticket
N/A

## Changes
*added ingress rule
## Context for reviewers
The eligibility screener container was successfully deployed, but it didn't allow traffic from the public internet. This PR points the public ip address to the exposed port `3000` 
## Testing
Ensure that you are able to use the ECS task public IP to access the screener

