### PR TITLE
WMDP-211 Generate API key

### DIFF
--- a/infra/mock_api/template/ecs.tf
+++ b/infra/mock_api/template/ecs.tf
@@ -128,7 +128,7 @@ resource "aws_ecs_task_definition" "mock-api-ecs-task-definition" {
         },
         {
           "name" : "POSTGRES_PASSWORD"
-          "value" : "${data.aws_ssm_parameter.db_pw.value}"
+          "value" : "${aws_ssm_parameter.random_db_password.value}"
         },
         {
           "name" : "POSTGRES_DB"
@@ -137,6 +137,10 @@ resource "aws_ecs_task_definition" "mock-api-ecs-task-definition" {
         {
           "name" : "DB_HOST"
           "value" : "${aws_db_instance.mock_api_db.address}"
+        },
+        {
+          "name" : "API_AUTH_TOKEN"
+          "value" : "${aws_ssm_parameter.random_api_key.value}"
         },
         {
           "name" : "LOG_FORMAT"
@@ -260,7 +264,7 @@ resource "aws_ecs_task_definition" "handle-csv" {
         },
         {
           "name" : "POSTGRES_PASSWORD"
-          "value" : "${data.aws_ssm_parameter.db_pw.value}"
+          "value" : "${aws_ssm_parameter.random_db_password.value}"
         },
         {
           "name" : "POSTGRES_DB"

--- a/infra/mock_api/template/rds.tf
+++ b/infra/mock_api/template/rds.tf
@@ -3,6 +3,7 @@
 # when 176 is merged:
 # update: common/mock_api_db/POSTGRES_PASSWORD in actual parameter store to prevent conflicts
 # update: what the rds setup considers a password
+# update: add updated auth token to ecs task
 
 resource "random_password" "random_db_password" {
   length           = 48
@@ -15,4 +16,17 @@ resource "aws_ssm_parameter" "random_db_password" {
   name  = "common/mock_api_db/POSTGRES_PASSWORD"
   type  = "SecureString"
   value = random_password.random_db_password.result
+}
+
+# Creates an API key we can use to auth containers with
+resource "random_password" "random_api_key" {
+  length           = 16
+  special          = true
+  min_special      = 6
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+resource "aws_ssm_parameter" "random_api_key" {
+  name  = "common/mock_api_db/API_AUTH_TOKEN"
+  type  = "SecureString"
+  value = random_password.random_api_key.result
 }

--- a/infra/mock_api/template/rds.tf
+++ b/infra/mock_api/template/rds.tf
@@ -1,6 +1,18 @@
-# rds config goes here
-# need db user and pw
-# need security group
-# use postgres instance
+# generates a secure password randomly
 
-# RDS IAM user
+# when 176 is merged:
+# update: common/mock_api_db/POSTGRES_PASSWORD in actual parameter store to prevent conflicts
+# update: what the rds setup considers a password
+
+resource "random_password" "random_db_password" {
+  length           = 48
+  special          = true
+  min_special      = 6
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_ssm_parameter" "random_db_password" {
+  name  = "common/mock_api_db/POSTGRES_PASSWORD"
+  type  = "SecureString"
+  value = random_password.random_db_password.result
+}

--- a/infra/mock_api/template/rds.tf
+++ b/infra/mock_api/template/rds.tf
@@ -13,7 +13,7 @@ resource "random_password" "random_db_password" {
 }
 
 resource "aws_ssm_parameter" "random_db_password" {
-  name  = "common/mock_api_db/POSTGRES_PASSWORD"
+  name  = "/common/mock_api_db/POSTGRES_PASSWORD"
   type  = "SecureString"
   value = random_password.random_db_password.result
 }
@@ -26,7 +26,7 @@ resource "random_password" "random_api_key" {
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 resource "aws_ssm_parameter" "random_api_key" {
-  name  = "common/mock_api_db/API_AUTH_TOKEN"
+  name  = "/common/mock_api_db/API_AUTH_TOKEN"
   type  = "SecureString"
   value = random_password.random_api_key.result
 }
@@ -66,7 +66,8 @@ resource "aws_db_instance" "mock_api_db" {
   apply_immediately               = true
   deletion_protection             = true
   storage_encrypted               = true
+  final_snapshot_identifier       = "${var.environment_name}-final"
   vpc_security_group_ids          = ["${aws_security_group.rds.id}"]
   username                        = data.aws_ssm_parameter.db_username.value
-  password                        = data.aws_ssm_parameter.db_pw.value
+  password                        = aws_ssm_parameter.random_db_password.value
 }

--- a/infra/mock_api/template/variables.tf
+++ b/infra/mock_api/template/variables.tf
@@ -12,6 +12,3 @@ variable "environment_name" {
 data "aws_ssm_parameter" "db_username" {
   name = "/common/mock_api_db/POSTGRES_USER"
 }
-data "aws_ssm_parameter" "db_pw" {
-  name = "/common/mock_api_db/POSTGRES_PASSWORD"
-}


### PR DESCRIPTION
## Ticket
https://wicmtdp.atlassian.net/browse/WMDP-211

## Changes
* added resources to manage randomly generated mock api key and db password

## Context for reviewers
* db password should be handled more sensitively
* key is necessary for mock api functionality


## Testing
These values should not:
* be shown in terraform output during commands such as `apply` or `plan`
* should be shown in the AWS console as a secure string

Steps to replicate:
1. authenticate the api with the generated key in parameter store
2. use the POST action
3. run the generate csv task

_below is the generated csv showing data from the database. (my mac decided to format it)_
<img width="1400" alt="Screen Shot 2022-09-22 at 1 42 56 PM" src="https://user-images.githubusercontent.com/37313082/191815658-6aa641dc-e289-445d-9803-aa920edda80f.png">
