### PR TITLE
Update Image Tagging

### DIFF
--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -75,8 +75,8 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
       logConfiguration = {
         logDriver = "awslogs",
         options = {
-          "awslogs-group"  = "${data.aws_cloudwatch_log_group.eligibility_screener.name}",
-          "awslogs-region" = "us-east-1",
+          "awslogs-group"         = "${data.aws_cloudwatch_log_group.eligibility_screener.name}",
+          "awslogs-region"        = "us-east-1",
           "awslogs-stream-prefix" = "screener"
         }
       }

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -63,7 +63,7 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
   container_definitions = jsonencode([
     {
       name      = "${var.environment_name}-eligibility-screener-container"
-      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/eligibility-screener-repo:latest"
+      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/eligibility-screener-repo:latest-${var.environment_name}"
       memory    = 1024
       cpu       = 512
       essential = true
@@ -75,8 +75,9 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
       logConfiguration = {
         logDriver = "awslogs",
         options = {
-          "awslogs-group"  = "${data.aws_cloudwatch_log_group.eligibility_screener}"
-          "awslogs-region" = "us-east-1"
+          "awslogs-group"  = "${data.aws_cloudwatch_log_group.eligibility_screener.name}",
+          "awslogs-region" = "us-east-1",
+          "awslogs-stream-prefix" = "screener"
         }
       }
     }

--- a/infra/mock_api/template/ecs.tf
+++ b/infra/mock_api/template/ecs.tf
@@ -101,7 +101,7 @@ resource "aws_ecs_task_definition" "mock-api-ecs-task-definition" {
   container_definitions = jsonencode([
     {
       name      = "${var.environment_name}-mock-api-container"
-      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest"
+      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest-${var.environment_name}"
       memory    = 1024
       cpu       = 512
       essential = true
@@ -150,7 +150,7 @@ resource "aws_ecs_task_definition" "mock-api-ecs-task-definition" {
       logConfiguration = {
         logDriver = "awslogs",
         options = {
-          "awslogs-group"         = "mock-api",
+          "awslogs-group"         = "${data.aws_cloudwatch_log_group.mock_api.name}",
           "awslogs-region"        = "us-east-1",
           "awslogs-stream-prefix" = "mock-api"
         }
@@ -237,7 +237,7 @@ resource "aws_ecs_task_definition" "handle-csv" {
   container_definitions = jsonencode([
     {
       name      = "${var.environment_name}-mock-api-container"
-      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest"
+      image     = "546642427916.dkr.ecr.us-east-1.amazonaws.com/mock-api-repo:latest-${var.environment_name}"
       memory    = 1024
       cpu       = 512
       essential = true


### PR DESCRIPTION
## Ticket
https://wicmtdp.atlassian.net/browse/WMDP-264


## Changes
* updated task definitions for screener and mock api
* updated log options block which generated a type error in terraform

## Context for reviewers
The mock api and the eligibility screener have been updated to have one "latest" tag per environment. However, the current ecs task definitions still referenced the old "latest" tag. This means that updated changes to the application weren't actually being hosted regardless of being pushed to the repo.

## Testing
Access either the eligibility screener or the api to check for updated changes.

_screener_
<img width="978" alt="Screen Shot 2022-10-06 at 2 22 11 PM" src="https://user-images.githubusercontent.com/37313082/194392857-ecee9b3e-7fc9-48b7-a479-4eb7572f31ea.png">

