### PR TITLE
WMDP-240 Add Load Balancer

### DIFF
--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -16,11 +16,11 @@ resource "aws_security_group" "allow-screener-traffic" {
     cidr_blocks = ["0.0.0.0/8"]
   }
   ingress {
-    description      = "VPC CIDR; allows healthchecks"
-    from_port        = 8080
-    protocol         = "tcp"
-    to_port          = 8080
-    cidr_blocks      = ["0.0.0.0/0"]
+    description = "VPC CIDR; allows healthchecks"
+    from_port   = 8080
+    protocol    = "tcp"
+    to_port     = 8080
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
@@ -46,22 +46,22 @@ resource "aws_security_group" "allow-lb-traffic" {
   vpc_id      = module.constants.vpc_id
 
   ingress {
-    description = "HTTP traffic from VPC"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "HTTP traffic from VPC"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description      = "allow lb traffic"
-    from_port        = 0
-    to_port          = 65535
-    protocol         = "tcp"
-    security_groups  = [
-        "sg-0c50cf775611d9db2",
-      ]
+    description = "allow lb traffic"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    security_groups = [
+      "sg-0c50cf775611d9db2",
+    ]
   }
   egress {
     description      = "allow all outbound traffic from screener"
@@ -80,10 +80,10 @@ resource "aws_security_group" "allow-lb-traffic" {
 # ---------------------------------------
 
 resource "aws_lb" "eligibility-screener" {
-  name = "${var.environment_name}-screener-lb"
-  internal = false
+  name               = "${var.environment_name}-screener-lb"
+  internal           = false
   load_balancer_type = "application"
-  security_groups = [aws_security_group.allow-lb-traffic.id]
+  security_groups    = [aws_security_group.allow-lb-traffic.id]
   subnets = [
     "subnet-05b0618f4ef1a808c",
     "subnet-06067596a1f981034",
@@ -92,29 +92,29 @@ resource "aws_lb" "eligibility-screener" {
     "subnet-09c317466f27bb9bb",
     "subnet-0ccc97c07aa49a0ae"
   ] # find a way to map all the default ones here; hardcoding for now
-  ip_address_type = "ipv4"
+  ip_address_type        = "ipv4"
   desync_mitigation_mode = "defensive"
 }
 
 # must be ip!!
 resource "aws_lb_target_group" "eligibility-screener" {
-  name = "${var.environment_name}-screener-lb"
-  port = 3000
-  protocol = "HTTP"
+  name        = "${var.environment_name}-screener-lb"
+  port        = 3000
+  protocol    = "HTTP"
   target_type = "ip"
-  vpc_id = module.constants.vpc_id
+  vpc_id      = module.constants.vpc_id
   health_check {
     enabled = true
-    port = 3000
+    port    = 3000
   }
 }
 
 resource "aws_lb_listener" "screener" {
   load_balancer_arn = aws_lb.eligibility-screener.arn
-  port = 80
-  protocol = "HTTP"
+  port              = 80
+  protocol          = "HTTP"
   default_action {
-    type = "forward"
+    type             = "forward"
     target_group_arn = aws_lb_target_group.eligibility-screener.arn
   }
 }
@@ -149,7 +149,7 @@ resource "aws_ecs_service" "eligibility-screener-ecs-service" {
     target_group_arn = aws_lb_target_group.eligibility-screener.arn
     # target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:546642427916:targetgroup/screener-lb-3000/72e92f65fe721cd1" # hardcoded for test purposes; wic-mt-screener target group
     container_name = "${var.environment_name}-eligibility-screener-container" # from the task definition 
-    container_port = 3000 # from the exposed docker container on the screener
+    container_port = 3000                                                     # from the exposed docker container on the screener
   }
 }
 data "aws_cloudwatch_log_group" "eligibility_screener" {

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -1,4 +1,8 @@
-# security group for screener
+# ---------------------------------------
+#
+# Security Groups
+#
+# ---------------------------------------
 resource "aws_security_group" "allow-screener-traffic" {
   name        = "allow_screener_traffic"
   description = "This rule blocks all traffic unless it is HTTPS for the eligibility screener"
@@ -11,6 +15,22 @@ resource "aws_security_group" "allow-screener-traffic" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/8"]
   }
+  ingress {
+    description      = "VPC CIDR; allows healthchecks"
+    from_port        = 8080
+    protocol         = "tcp"
+    to_port          = 8080
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+  # ingress {
+  #   description      = "allow lb traffic"
+  #   from_port        = 0
+  #   to_port          = 65535
+  #   protocol         = "tcp"
+  #   security_groups  = [
+  #       "sg-0c50cf775611d9db2",
+  #     ]
+  # }
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Allow traffic from internet"
@@ -28,6 +48,71 @@ resource "aws_security_group" "allow-screener-traffic" {
   }
 }
 
+resource "aws_security_group" "allow-lb-traffic" {
+  name        = "screener_load_balancer_sg"
+  description = "Allows load balancers to communicate with tasks"
+  vpc_id      = module.constants.vpc_id
+
+  ingress {
+    description = "HTTP traffic from VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "allow lb traffic"
+    from_port        = 0
+    to_port          = 65535
+    protocol         = "tcp"
+    security_groups  = [
+        "sg-0c50cf775611d9db2",
+      ]
+  }
+  egress {
+    description      = "allow all outbound traffic from screener"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+# ---------------------------------------
+#
+# Load Balancing
+#
+# ---------------------------------------
+
+resource "aws_lb" "eligibility-screener" {
+  name = "${var.environment_name}-screener-lb"
+  internal = false
+  load_balancer_type = "application"
+  security_groups = [aws_security_group.allow-lb-traffic.id]
+  subnets = [
+    "subnet-05b0618f4ef1a808c",
+    "subnet-06067596a1f981034",
+    "subnet-06b4ec8ff6311f69d",
+    "subnet-08d7f1f9802fd20c4",
+    "subnet-09c317466f27bb9bb",
+    "subnet-0ccc97c07aa49a0ae"
+  ] # find a way to map all the default ones here; hardcoding for now
+  ip_address_type = "ipv4"
+  desync_mitigation_mode = "defensive"
+}
+
+# must be ip!!
+resource "aws_lb_target_group" "eligibility-screener" {
+  
+}
+# ---------------------------------------
+#
+# ECS
+#
+# ---------------------------------------
 resource "aws_ecs_cluster" "eligibility-screener-ecs-cluster" {
   name = var.environment_name
 }
@@ -49,10 +134,17 @@ resource "aws_ecs_service" "eligibility-screener-ecs-service" {
     rollback = true
   }
   force_new_deployment = true
+
+  load_balancer {
+    target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:546642427916:targetgroup/screener-lb-3000/72e92f65fe721cd1" # hardcoded for test purposes; wic-mt-screener target group
+    container_name = "${var.environment_name}-eligibility-screener-container" # from the task definition 
+    container_port = 3000 # from the exposed docker container on the screener
+  }
 }
 data "aws_cloudwatch_log_group" "eligibility_screener" {
   name = "screener"
 }
+
 resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
   family                   = "${var.environment_name}-screener-task-definition"
   network_mode             = "awsvpc"

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -138,8 +138,8 @@ resource "aws_ecs_service" "eligibility-screener-ecs-service" {
 
   load_balancer {
     target_group_arn = aws_lb_target_group.eligibility-screener.arn
-    container_name = local.container_name # from the task definition 
-    container_port = 3000  # from the exposed docker container on the screener
+    container_name   = local.container_name # from the task definition 
+    container_port   = 3000                 # from the exposed docker container on the screener
   }
 }
 data "aws_cloudwatch_log_group" "eligibility_screener" {

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -18,14 +18,6 @@ resource "aws_security_group" "allow-screener-traffic" {
   vpc_id      = module.constants.vpc_id
 
   ingress {
-    description = "HTTP traffic from VPC"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/8"]
-  }
-
-  ingress {
     cidr_blocks = ["0.0.0.0/0"]
     description = "Allow traffic from internet"
     from_port   = 3000
@@ -48,7 +40,7 @@ resource "aws_security_group" "allow-lb-traffic" {
   vpc_id      = module.constants.vpc_id
 
   ingress {
-    description      = "HTTP traffic from VPC"
+    description      = "HTTP traffic from anywhere"
     from_port        = 80
     to_port          = 80
     protocol         = "tcp"


### PR DESCRIPTION
## Ticket
https://wicmtdp.atlassian.net/browse/WMDP-240

## Changes
* add load balancer and associated resources (e.g. listener)
* update security group
* update container port for the eligibility screener
* associated lb with ecs service
* made `ecs.tf` easier to read

## Context for reviewers
> We need a “static” IP for our eligibility screener, which will allow us to have an easier link to use when conducting tests. This will also streamline the process for adding DNS.

## Testing
Link to application in ticket.
Checked that:
- application and all assets load properly (e.g. dropdowns)
- activity on the load balancer link matches activity using the public ip on the ECS task and local environments
- the application loads properly on mobile

_screenshot from the load balancer link, which matches the current image in AWS_
<img width="803" alt="Screen Shot 2022-10-17 at 2 22 20 PM" src="https://user-images.githubusercontent.com/37313082/196253459-ee1f9a24-2d9f-4706-b96a-b385a5256efb.png">

