### PR TITLE
WMDP-216 CD should fail if ECS isn't stable

### DIFF
--- a/infra/aws_bootstrap/iam.tf
+++ b/infra/aws_bootstrap/iam.tf
@@ -100,7 +100,7 @@ resource "aws_iam_role_policy_attachment" "github_actions" {
 data "aws_iam_policy_document" "deploy_action" {
   statement {
     sid     = "WICUpdateECR"
-    actions = ["ecs:UpdateCluster", "ecs:UpdateService","ecs:DescribeClusters", "ecs:DescribeServices", "ecr:*"]
+    actions = ["ecs:UpdateCluster", "ecs:UpdateService", "ecs:DescribeClusters", "ecs:DescribeServices", "ecr:*"]
     resources = [
       "arn:aws:ecs:us-east-1:546642427916:service/${var.environment_name}/*",
       "arn:aws:ecs:us-east-1:546642427916:cluster/${var.environment_name}",

--- a/infra/aws_bootstrap/iam.tf
+++ b/infra/aws_bootstrap/iam.tf
@@ -100,7 +100,7 @@ resource "aws_iam_role_policy_attachment" "github_actions" {
 data "aws_iam_policy_document" "deploy_action" {
   statement {
     sid     = "WICUpdateECR"
-    actions = ["ecs:UpdateCluster", "ecs:UpdateService", "ecr:*"]
+    actions = ["ecs:UpdateCluster", "ecs:UpdateService","ecs:DescribeClusters", "ecs:DescribeServices", "ecr:*"]
     resources = [
       "arn:aws:ecs:us-east-1:546642427916:service/${var.environment_name}/*",
       "arn:aws:ecs:us-east-1:546642427916:cluster/${var.environment_name}",


### PR DESCRIPTION
## Ticket
https://wicmtdp.atlassian.net/browse/WMDP-216

## Changes
* update GitHub actions IAM role

## Context for reviewers
In order to apply these changes, this PR has changes in three places:

* in the eligibility screener and the mock-api repo an additional CD step has been added
* in the infra repo, the IAM role has been updated to allow ecs:DescribeClusters and ecs:DescribeServices

## Testing
See: https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/139

