### PR TITLE
Update connections between the screener and the mock api

### DIFF
--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -137,6 +137,9 @@ resource "aws_ecs_service" "eligibility-screener-ecs-service" {
 data "aws_cloudwatch_log_group" "eligibility_screener" {
   name = "screener"
 }
+data "aws_ssm_parameter" "random_api_key" {
+  name = "/common/mock_api_db/API_AUTH_TOKEN"
+}
 
 resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
   family                   = "${var.environment_name}-screener-task-definition"
@@ -155,6 +158,16 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
       portMappings = [
         {
           containerPort : 3000
+        }
+      ],
+      environment: [
+        {
+          "name": "API_HOST"
+          "value": "http://test-mock-api-lb-2033452615.us-east-1.elb.amazonaws.com:80" # hardcoded for persistience, mockapi load balancer DNS name
+        },
+        {
+          "name" : "API_AUTH_TOKEN"
+          "value" : "${data.aws_ssm_parameter.random_api_key.value}"
         }
       ],
       logConfiguration = {

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -160,10 +160,10 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
           containerPort : 3000
         }
       ],
-      environment: [
+      environment : [
         {
-          "name": "API_HOST"
-          "value": "http://test-mock-api-lb-2033452615.us-east-1.elb.amazonaws.com:80" # hardcoded for persistience, mockapi load balancer DNS name
+          "name" : "API_HOST"
+          "value" : "http://test-mock-api-lb-2033452615.us-east-1.elb.amazonaws.com:80" # hardcoded for persistience, mockapi load balancer DNS name
         },
         {
           "name" : "API_AUTH_TOKEN"

--- a/infra/mock_api/template/ecs.tf
+++ b/infra/mock_api/template/ecs.tf
@@ -1,4 +1,4 @@
-locals{
+locals {
   container_name = "${var.environment_name}-mock-api-container"
 }
 # ---------------------------------------
@@ -7,13 +7,13 @@ locals{
 #
 # ---------------------------------------
 data "aws_security_group" "allow-lb-traffic" {
-  name        = "screener_load_balancer_sg"
+  name = "screener_load_balancer_sg"
 }
 resource "aws_lb" "mock_api" {
   name               = "${var.environment_name}-mock-api-lb"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = [data.aws_security_group.allow-lb-traffic.id] 
+  security_groups    = [data.aws_security_group.allow-lb-traffic.id]
   subnets = [
     "subnet-05b0618f4ef1a808c",
     "subnet-06067596a1f981034",
@@ -35,7 +35,7 @@ resource "aws_lb_target_group" "mock_api" {
   health_check {
     enabled = true
     port    = 8080
-    path = "/v1/healthcheck"
+    path    = "/v1/healthcheck"
   }
 }
 
@@ -115,10 +115,10 @@ resource "aws_security_group" "allow-api-traffic" {
 
   # This is for testing purposes ONLY
   ingress {
-    description = "Limit traffic to just the screener"
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
+    description     = "Limit traffic to just the screener"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
     security_groups = [data.aws_security_group.allow-lb-traffic.id]
   }
 


### PR DESCRIPTION
## Ticket
https://wicmtdp.atlassian.net/browse/{TICKET_ID}

## Changes
- add env vars to the screener ecs task
- add load balancer in front of mock api
- update mock api security group rules
- minor readability changes

## Context for reviewers
Following the work merged in the [eligibility screener refactor](https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/149), the ecs task that manages the eligibility screener needed a few environment variables to ensure that it could communicate with the mock_api

_The resulting error from Rocket_
![image](https://user-images.githubusercontent.com/37313082/199321948-d7399f4d-c9cd-496a-8bf7-2aba837110ca.png)


## Testing

Application Flow:
1. Visit: http://wic-eligibility.demo.navapbc.com/ and fill out the eligibility screener
2. Check that you can submit an application and get to the confirmation page

Security groups:
1. log into the AWS console and navigate to the mock_api ecs task, and copy the public_ip address
2. attempt to navigate to this address: `public_ip:8080/v1/docs`
3. the connection should either time-out or be refused

Database/S3 connection:
1. in the AWS console navigate to the `test-api-csv` bucket. 
2. check for the file `2022-11-01-19-18-05-eligibility-screener.csv`
3. check that it has a few test records like this:
![Screen Shot 2022-11-01 at 3 36 26 PM](https://user-images.githubusercontent.com/37313082/199322979-7bc5628b-5598-4b36-b4b4-6e7f381807ca.png)

4. clone the mock api repo
5. cd to `app/bin/run-ecs-task/`
6. run this command: `run-task.sh -a your.name -e test -t test-csv-handler-definition -g '["sg-079fad630bf4fe18a"]'`
7. In the AWS console navigate back to the `test-api-csv` bucket for a new file. 
8. Check that this file has the information from the Application flow test

