### PR TITLE
Update Demo project

### DIFF
--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -47,6 +47,14 @@ resource "aws_security_group" "allow-lb-traffic" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+  ingress {
+    description      = "HTTPS traffic from anywhere"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
   egress {
     description      = "allow all outbound traffic from load balancer"
     from_port        = 0
@@ -92,13 +100,29 @@ resource "aws_lb_target_group" "eligibility-screener" {
   }
 }
 
+resource "aws_lb_listener" "screener_secure" {
+  load_balancer_arn = aws_lb.eligibility-screener.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:acm:us-east-1:546642427916:certificate/91022588-849d-4b53-8ad1-b649607795ae"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.eligibility-screener.arn
+  }
+}
+
 resource "aws_lb_listener" "screener" {
   load_balancer_arn = aws_lb.eligibility-screener.arn
   port              = 80
   protocol          = "HTTP"
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.eligibility-screener.arn
+    type             = "redirect"
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 # ---------------------------------------
@@ -161,6 +185,10 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
         }
       ],
       environment : [
+        {
+          "name": "NEXT_PUBLIC_DEMO_MODE"
+          "value": "true"
+        },
         {
           "name" : "API_HOST"
           "value" : "http://test-mock-api-lb-2033452615.us-east-1.elb.amazonaws.com:80" # hardcoded for persistience, mockapi load balancer DNS name

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -117,10 +117,10 @@ resource "aws_lb_listener" "screener" {
   port              = 80
   protocol          = "HTTP"
   default_action {
-    type             = "redirect"
+    type = "redirect"
     redirect {
-      port = "443"
-      protocol = "HTTPS"
+      port        = "443"
+      protocol    = "HTTPS"
       status_code = "HTTP_301"
     }
   }
@@ -186,8 +186,8 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
       ],
       environment : [
         {
-          "name": "NEXT_PUBLIC_DEMO_MODE"
-          "value": "true"
+          "name" : "NEXT_PUBLIC_DEMO_MODE"
+          "value" : "true"
         },
         {
           "name" : "API_HOST"

--- a/infra/eligibility_screener/template/ecs.tf
+++ b/infra/eligibility_screener/template/ecs.tf
@@ -186,10 +186,6 @@ resource "aws_ecs_task_definition" "eligibility-screener-ecs-task-definition" {
       ],
       environment : [
         {
-          "name" : "NEXT_PUBLIC_DEMO_MODE"
-          "value" : "true"
-        },
-        {
           "name" : "API_HOST"
           "value" : "http://test-mock-api-lb-2033452615.us-east-1.elb.amazonaws.com:80" # hardcoded for persistience, mockapi load balancer DNS name
         },


### PR DESCRIPTION
## Ticket


## Changes
* move resources that were managed manually into terraform (e.g. port 443 listener)

## Context for reviewers
https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/167 implemented a demo mode which prevents data from being sent to the mock api. This needed to be added to the eligibility screener ecs task and then deployed separately.

## Testing
cd into `infra/eligibility_screener/environments/test`
run `terraform state list` 
Log into AWS and confirm that the resources listed in the `terraform state list` output exist in the AWS workspace.

(Ordinarily, I would suggest running `terraform plan` and confirming that no changes need to be made, however I need to debug an issue where the state is inconsistent across some devices) 

