### PR TITLE
Add documentation for running screener and mock api locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ override.tf.json
 # example: *tfplan*
 *.plan
 *.tfstate
+
+# Ignore eligibility screener and mock api cloned repos
+eligibility-screener/
+mock-api/

--- a/README.md
+++ b/README.md
@@ -65,3 +65,20 @@ ECS tasks: This logging group contains varying information about the ECS tasks t
 RDS: This logging group contains information about RDS events. Examples include: creating checkpoints and how long that process took to complete.
 
 Container insights: This logging group contains metrics about Fargate tasks such as CPU and reserved memory
+
+## Local Development
+
+To run the eligibility screener and the Mock API in development mode locally:
+
+1. Navigate to the root directory of this repo
+2. Clone the eligibility screener repo: `git clone git@github.com:navapbc/wic-mt-demo-project-eligibility-screener.git eligibility-screener`
+3. Clone the mock API repo: `git clone git@github.com:navapbc/wic-mt-demo-project-mock-api.git mock-api`
+4. Build the docker images and start the containers (it will start 3 containers: mock api, eligibility screener, postgresql): `docker-compose up -d --build`
+5. If this is the first time you are running the mock API, then it will crash because the database migrations haven't been run yet. Run them and then restart the container: `docker-compose run --rm mock-api poetry run db-migrate-up && docker-compose up -d`
+6. Run storybook: `docker-compose exec eligibility-screener yarn storybook`
+
+Now you can navigate to:
+
+- `localhost:3000` to access the eligibility screener
+- `localhost:8080/v1/docs` to access the swagger docs
+- `localhost:6006` to access storybook

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+# This docker compose file is ONLY used for local development and NOT for deploys.
+version: '3'
+
+services:
+  eligibility-screener:
+    build:
+      context: ./eligibility-screener/app
+    # Run in development mode
+    command: ["yarn", "dev"]
+    # Load environment variables for local development
+    env_file: ./mock-api/app/local.env
+    environment:
+      - API_HOST=http://mock-api:8080
+      - NEXT_PUBLIC_DEMO_MODE="false"
+    # Fix running on Apple silicon
+    platform: linux/amd64
+    ports:
+      # Expose a port to access the application.
+      - 3000:3000
+      # Expose a port for storybook.
+      - 6006:6006
+    volumes:
+      # Use a named volume for the node_modules so that the container uses the guest machine's node_modules dir instead of the host machine's node_modules directory, which might be divergent.
+      - nextjs_nodemodules:/srv/node_modules
+
+  mock-api-db:
+    image: postgres:14-alpine
+    # Docs for options to the postgres server command:
+    # https://www.postgresql.org/docs/current/app-postgres.html
+    command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
+    # Load environment variables for local development. 
+    env_file: ./mock-api/app/local.env
+    # Fix running on Apple silicon
+    platform: linux/amd64
+    ports:
+      - 5432:5432
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  mock-api:
+    build:
+      context: ./mock-api/app
+    # Load environment variables for local development
+    env_file: ./mock-api/app/local.env
+    # NOTE: These values take precedence if the same value is specified in the env_file.
+    environment:
+      # The env_file defines DB_HOST=localhost for accessing a non-dockerized database. 
+      # In the docker-compose, we tell the app to use the dockerized database service 
+      - DB_HOST=mock-api-db
+    # Fix running on Apple silicon
+    platform: linux/amd64
+    # Expose the application port for local development.
+    ports: 
+      - 8080:8080
+    depends_on:
+      - mock-api-db
+
+volumes:
+  db_data:
+  nextjs_nodemodules:


### PR DESCRIPTION
## Ticket

- N/A

## Changes
> What was added, updated, or removed in this PR.

- Add documentation for how to run the eligibility screener and mock API together locally
- Add example `docker-compose.yml` to do so
- Ignore local dirs for eligibility screener and mock API

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This PR adds directions for how to run the mock API and the screener together locally, rather than just in AWS.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

Run through the new directions in the README.md